### PR TITLE
fix d2 file perms

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-d2-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-d2-config/run
@@ -151,4 +151,6 @@ fi
 
 shopt -u globstar
 
-lsiown abc:abc "/output/${OUTPUTNAME}"
+lsiown abc:abc \
+    /output \
+    "/output/${OUTPUTNAME}"

--- a/root/etc/s6-overlay/s6-rc.d/init-d2-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-d2-config/run
@@ -150,3 +150,5 @@ EOF
 fi
 
 shopt -u globstar
+
+lsiown abc:abc "/output/${OUTPUTNAME}"


### PR DESCRIPTION
currently the generated d2 file is owned by root and the svg generation fails as a result

```
$ docker run --rm -v /tmp/d2:/output -e PUID=99 -e PGID=100 ghcr.io/linuxserver/d2-builder:latest synclounge:latest
[migrations] started
[migrations] no migrations found
───────────────────────────────────────

      ██╗     ███████╗██╗ ██████╗
      ██║     ██╔════╝██║██╔═══██╗
      ██║     ███████╗██║██║   ██║
      ██║     ╚════██║██║██║   ██║
      ███████╗███████║██║╚██████╔╝
      ╚══════╝╚══════╝╚═╝ ╚═════╝

   Brought to you by linuxserver.io
───────────────────────────────────────

To support LSIO projects visit:
https://www.linuxserver.io/donate/

───────────────────────────────────────
GID/UID
───────────────────────────────────────

User UID:    99
User GID:    100
───────────────────────────────────────
Version: v0.6.8-ls1
Build-date: 2024-11-18T16:27:39+00:00
───────────────────────────────────────
    
Cloning into '/tmp/synclounge'...
Cloning into '/tmp/baseimage-alpine'...
err: failed to compile ../../../../output/synclounge-latest.d2: open /output/synclounge-latest.svg: permission denied
chmod: cannot access '/output/synclounge-latest.svg': No such file or directory
s6-rc: warning: unable to start service init-d2-output: command exited 1
/run/s6/basedir/scripts/rc.init: warning: s6-rc failed to properly bring all the services up! Check your logs (in /run/uncaught-logs/current if you have in-container logging) for more information.
/run/s6/basedir/scripts/rc.init: fatal: stopping the container.
```